### PR TITLE
PHP 8 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
         "wiki": "https://github.com/arcticfalcon/emv-qr-cps/wiki"
     },
     "require": {
-        "php": "^8.0.2"
+        "php": "^7.4 || ^8.0.2"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-mockery": "^1.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^8.5 || ^9.5",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
         "wiki": "https://github.com/arcticfalcon/emv-qr-cps/wiki"
     },
     "require": {
-        "php": "^7.1"
+        "php": "^8.0.2"
     },
     "require-dev": {
-        "jakub-onderka/php-parallel-lint": "^1",
-        "mockery/mockery": "^1",
-        "phpstan/phpstan": "^0.10",
-        "phpstan/phpstan-mockery": "^0.10",
-        "phpunit/phpunit": "^7",
-        "squizlabs/php_codesniffer": "^3"
+        "mockery/mockery": "^1.5",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "phpstan/phpstan": "^1.4",
+        "phpstan/phpstan-mockery": "^1.0",
+        "phpunit/phpunit": "^9.5",
+        "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
El paquete **jakub-onderka/php-parallel-lint** está deprecado. Lo cambié a **php-parallel-lint/php-parallel-lint**.